### PR TITLE
compile error when using modbus select inside esphome code

### DIFF
--- a/components/modbus_bridge/modbus_bridge.cpp
+++ b/components/modbus_bridge/modbus_bridge.cpp
@@ -15,11 +15,7 @@
 #ifdef USE_ESP32
 +#include <lwip/sockets.h>
 +#include <lwip/netdb.h>
-+#include <lwip/inet.h>
-+#include <lwip/tcp.h>
-+#include <fcntl.h>
-+#include <sys/time.h>
-+#include <errno.h>
+#include <fcntl.h>
 #endif
 
 #include "modbus_bridge.h"

--- a/components/modbus_bridge/modbus_bridge.cpp
+++ b/components/modbus_bridge/modbus_bridge.cpp
@@ -13,8 +13,8 @@
 
 
 #ifdef USE_ESP32
-+#include <lwip/sockets.h>
-+#include <lwip/netdb.h>
+#include <lwip/sockets.h>
+#include <lwip/netdb.h>
 #include <fcntl.h>
 #endif
 

--- a/components/modbus_bridge/modbus_bridge.cpp
+++ b/components/modbus_bridge/modbus_bridge.cpp
@@ -13,8 +13,13 @@
 
 
 #ifdef USE_ESP32
-#include <lwip/sockets.h>
-#include <fcntl.h>
++#include <lwip/sockets.h>
++#include <lwip/netdb.h>
++#include <lwip/inet.h>
++#include <lwip/tcp.h>
++#include <fcntl.h>
++#include <sys/time.h>
++#include <errno.h>
 #endif
 
 #include "modbus_bridge.h"
@@ -552,7 +557,7 @@ void ModbusBridgeComponent::check_tcp_sockets_() {
   }
 
   struct timeval timeout = {0, 0};
-  int sel = select(maxfd + 1, &read_fds, NULL, NULL, &timeout);
+  int sel = lwip_select(maxfd + 1, &read_fds, NULL, NULL, &timeout);
   if (sel < 0) return;
 
   if (FD_ISSET(this->sock_, &read_fds)) {


### PR DESCRIPTION
Hi

I got this compile error on my yaml:
[my yaml file](https://github.com/fonske/MarstekVenus-M5stackRS485/blob/main/esphome/atom_s3_lite_rs485_tcp_ip.yaml)

`src/esphome/components/modbus_bridge/modbus_bridge.cpp: In member function 'void esphome::modbus_bridge::ModbusBridgeComponent::check_tcp_sockets_()': src/esphome/components/modbus_bridge/modbus_bridge.cpp:555:19: error: expected primary-expression before '(' token 555 | int sel = select(maxfd + 1, &read_fds, NULL, NULL, &timeout); | ^ Compiling .pioenvs/marstek_m1/src/esphome/components/modbus_controller/text_sensor/modbus_textsensor.cpp.o *** [.pioenvs/marstek_m1/src/esphome/components/modbus_bridge/modbus_bridge.cpp.o] Error 1`

Chatgpt came up with a solution and no more compile error