### PR TITLE
Add echo stripper for half-duplex RS-485 devices

### DIFF
--- a/components/modbus_bridge/modbus_bridge.cpp
+++ b/components/modbus_bridge/modbus_bridge.cpp
@@ -1444,6 +1444,31 @@ namespace esphome
         return; // still within overall timeout
       }
 
+      // Strip echo and bus noise: find the real response start
+      // Real response always starts with expected UID (0x01)
+      // followed by the same FC as the request
+      if (current_size > 2 && !pending.rtu_data.empty())
+      {
+        const uint8_t expected_uid = pending.rtu_data[0];
+        const uint8_t expected_fc  = pending.rtu_data[1];
+        // Search for UID+FC pattern starting from byte 1 (byte 0 might be correct already)
+        for (size_t i = 1; i + 1 < current_size; i++)
+        {
+          if (pending.response[i]     == expected_uid &&
+              pending.response[i + 1] == expected_fc)
+          {
+            pending.response.erase(pending.response.begin(),
+                                  pending.response.begin() + i);
+            current_size = pending.response.size();
+            pending.last_size = current_size;
+            pending.stable_polls = 0;
+            if (this->debug_)
+              ESP_LOGD(TAG, "Stripped %u leading bytes (echo/noise)", (unsigned)i);
+            break;
+          }
+        }
+      }
+
       // --- End-of-frame detection by size stability over consecutive polls ---
       // Consider the RTU response complete once we have observed no growth in
       // `pending.response.size()` for two consecutive polling intervals.


### PR DESCRIPTION
When using a half-duplex RS-485 transceiver, the transmitted bytes can echo back on the RX line before the slave device responds. This causes the response buffer to contain the tail of the TX frame prepended to the real response, which then fails CRC validation and gets dropped.
This change scans the received buffer for the first occurrence of expected_UID + expected_FC and strips any preceding bytes, allowing the CRC check to operate on the clean response frame.
Tested with LK ICS.2 underfloor heating controller at 19200 baud, ODD parity, using Waveshare RS485 3.3V board on ESP32 D1 Mini.